### PR TITLE
feat: support for prompt-file parameter

### DIFF
--- a/.github/prompts/ai.md
+++ b/.github/prompts/ai.md
@@ -1,0 +1,1 @@
+Is AI going to replace humans?

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,16 +11,26 @@ permissions:
   models: read
 
 jobs:
-  test-action:
-    name: Test Action
+  test-action-prompt:
+    name: Test Action with Prompt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Test action functionality
+      - name: Test action
         id: test
         uses: ./
         with:
           prompt: "What is the meaning of life?"
+
+  test-action-prompt-file:
+    name: Test Action with Prompt File
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test action
+        uses: ./
+        with:
+          prompt-file: ".github/prompts/ai.md"
 
   test-typescript:
     name: TypeScript Unit Tests

--- a/README.md
+++ b/README.md
@@ -1,3 +1,69 @@
 # ask-ai action
 
-Work in progress! :robot:
+A GitHub Action that lets you ask AI questions directly in your workflows.
+
+## Usage
+
+You can use this action in two ways:
+
+1. By providing a direct prompt:
+```yaml
+- uses: FidelusAleksander/ask-ai@main
+  with:
+    prompt: "What is the meaning of life?"
+```
+
+2. By loading a prompt from a file:
+```yaml
+- uses: FidelusAleksander/ask-ai@main
+  with:
+    prompt-file: .github/prompts/my-prompt.txt
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `prompt` | The text prompt to send to the AI | No* | - |
+| `prompt-file` | Path to a file containing the prompt | No* | - |
+| `token` | Personal access token | Yes | `${{ github.token }}` |
+| `model` | The AI model to use | No | `gpt-4o` |
+
+\* Either `prompt` or `prompt-file` must be provided
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `text` | The AI's response to your prompt |
+
+## Examples
+
+### Using a direct prompt
+```yaml
+- name: Ask AI a question
+  uses: FidelusAleksander/ask-ai@main
+  with:
+    prompt: "What are the best practices for writing GitHub Actions?"
+```
+
+### Using a prompt file
+```yaml
+- name: Ask AI with prompt from file
+  uses: FidelusAleksander/ask-ai@main
+  with:
+    prompt-file: .github/prompts/code-review.txt
+```
+
+### Using both in different steps
+```yaml
+- name: Code review with AI
+  uses: FidelusAleksander/ask-ai@main
+  with:
+    prompt-file: .github/prompts/code-review.txt
+
+- name: Follow-up question
+  uses: FidelusAleksander/ask-ai@main
+  with:
+    prompt: "Can you explain that in simpler terms?"
+```

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,0 +1,134 @@
+const mockCore = {
+  getInput: jest.fn(),
+  setOutput: jest.fn(),
+  setFailed: jest.fn(),
+  startGroup: jest.fn(),
+  endGroup: jest.fn(),
+};
+
+const mockFs = {
+  existsSync: jest.fn(),
+  readFileSync: jest.fn(),
+};
+
+const mockGenerateAIResponse = jest.fn();
+
+jest.mock("@actions/core", () => mockCore);
+jest.mock("fs", () => mockFs);
+jest.mock("../src/ai", () => ({
+  generateAIResponse: mockGenerateAIResponse,
+}));
+
+describe("GitHub Action", () => {
+  const mockToken = "test-token";
+  const mockModel = "test-model";
+  const mockPrompt = "test prompt";
+  const mockResponse = "test response";
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockGenerateAIResponse.mockResolvedValue(mockResponse);
+    mockCore.getInput.mockImplementation((name: string) => {
+      switch (name) {
+        case "token":
+          return mockToken;
+        case "model":
+          return mockModel;
+        default:
+          return "";
+      }
+    });
+  });
+
+  it("should work with prompt input", async () => {
+    mockCore.getInput.mockImplementation((name: string) => {
+      switch (name) {
+        case "prompt":
+          return mockPrompt;
+        case "token":
+          return mockToken;
+        case "model":
+          return mockModel;
+        default:
+          return "";
+      }
+    });
+
+    await import("../src/index");
+
+    expect(mockGenerateAIResponse).toHaveBeenCalledWith(
+      mockPrompt,
+      mockModel,
+      mockToken,
+    );
+    expect(mockCore.setOutput).toHaveBeenCalledWith("text", mockResponse);
+  });
+
+  it("should work with prompt-file input", async () => {
+    const promptFilePath = "test-prompt.txt";
+    const fileContent = "prompt from file";
+
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue(fileContent);
+    mockCore.getInput.mockImplementation((name: string) => {
+      switch (name) {
+        case "prompt-file":
+          return promptFilePath;
+        case "token":
+          return mockToken;
+        case "model":
+          return mockModel;
+        default:
+          return "";
+      }
+    });
+
+    await import("../src/index");
+
+    expect(mockFs.existsSync).toHaveBeenCalledWith(promptFilePath);
+    expect(mockFs.readFileSync).toHaveBeenCalledWith(promptFilePath, "utf8");
+    expect(mockGenerateAIResponse).toHaveBeenCalledWith(
+      fileContent,
+      mockModel,
+      mockToken,
+    );
+    expect(mockCore.setOutput).toHaveBeenCalledWith("text", mockResponse);
+  });
+
+  it("should throw error when prompt file doesn't exist", async () => {
+    const promptFilePath = "non-existent.txt";
+
+    mockFs.existsSync.mockReturnValue(false);
+    mockCore.getInput.mockImplementation((name: string) => {
+      switch (name) {
+        case "prompt-file":
+          return promptFilePath;
+        case "token":
+          return mockToken;
+        case "model":
+          return mockModel;
+        default:
+          return "";
+      }
+    });
+
+    await import("../src/index");
+
+    expect(mockCore.setFailed).toHaveBeenCalledWith(
+      `Prompt file not found: ${promptFilePath}`,
+    );
+  });
+
+  it("should throw error when neither prompt nor prompt-file is provided", async () => {
+    await import("../src/index");
+
+    expect(mockCore.setFailed).toHaveBeenCalledWith(
+      "Either 'prompt' or 'prompt-file' input must be provided",
+    );
+  });
+
+  // Clear the module cache after each test
+  afterEach(() => {
+    jest.resetModules();
+  });
+});

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,11 @@ inputs:
   prompt:
     description: >
       What do you want to ask?
-    required: true
+    required: false
+  prompt-file:
+    description: >
+      Path to a file containing the prompt
+    required: false
   model:
     description: >
       The AI model to use for generating the response

--- a/dist/index.js
+++ b/dist/index.js
@@ -73,12 +73,27 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core = __importStar(__nccwpck_require__(7484));
+const fs = __importStar(__nccwpck_require__(9896));
 const ai_1 = __nccwpck_require__(8391);
 async function run() {
     try {
-        const prompt = core.getInput("prompt", { required: true });
+        const promptFile = core.getInput("prompt-file");
+        const promptText = core.getInput("prompt");
         const token = core.getInput("token", { required: true });
         const model = core.getInput("model", { required: true });
+        let prompt;
+        if (promptFile) {
+            if (!fs.existsSync(promptFile)) {
+                throw new Error(`Prompt file not found: ${promptFile}`);
+            }
+            prompt = fs.readFileSync(promptFile, "utf8");
+        }
+        else if (promptText) {
+            prompt = promptText;
+        }
+        else {
+            throw new Error("Either 'prompt' or 'prompt-file' input must be provided");
+        }
         // Generate AI response
         console.log(`Prompting ${model} AI model`);
         const response = await (0, ai_1.generateAIResponse)(prompt, model, token);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,27 @@
 import * as core from "@actions/core";
+import * as fs from "fs";
 import { generateAIResponse } from "./ai";
 
 async function run() {
   try {
-    const prompt = core.getInput("prompt", { required: true });
+    const promptFile = core.getInput("prompt-file");
+    const promptText = core.getInput("prompt");
     const token = core.getInput("token", { required: true });
     const model = core.getInput("model", { required: true });
+
+    let prompt: string;
+    if (promptFile) {
+      if (!fs.existsSync(promptFile)) {
+        throw new Error(`Prompt file not found: ${promptFile}`);
+      }
+      prompt = fs.readFileSync(promptFile, "utf8");
+    } else if (promptText) {
+      prompt = promptText;
+    } else {
+      throw new Error(
+        "Either 'prompt' or 'prompt-file' input must be provided",
+      );
+    }
 
     // Generate AI response
     console.log(`Prompting ${model} AI model`);


### PR DESCRIPTION
This pull request introduces significant enhancements to the `ask-ai` GitHub Action, focusing on adding prompt file support, updating documentation, and improving test coverage.

### New Features and Improvements:

* **Prompt File Support:**
  * Added support for loading prompts from a file in `action.yml` and `src/index.ts`. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L12-R16) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R2-R25)
  * Updated `README.md` with usage examples for both direct prompts and prompt files.

* **Workflow Updates:**
  * Modified `.github/workflows/test.yml` to include new jobs that test the action with direct prompts and prompt files.

* **Testing Enhancements:**
  * Added comprehensive tests in `__tests__/index.test.ts` to cover scenarios for direct prompts, prompt files, and error handling.

* **Documentation:**
  * Updated `README.md` to provide detailed usage instructions, input descriptions, and examples.

* **Miscellaneous:**
  * Added a new prompt example in `.github/prompts/ai.md`.