### PR TITLE
add update-major-version workflow

### DIFF
--- a/.github/workflows/update-major-version.yml
+++ b/.github/workflows/update-major-version.yml
@@ -1,0 +1,30 @@
+name: Update Main Version
+run-name: Move ${{ github.event.inputs.major_version }} to ${{ github.event.inputs.target }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: The tag or reference to use
+        required: true
+      major_version:
+        type: choice
+        description: The major version to update
+        options:
+          - v1
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Git config
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Tag new target
+        run: git tag -f ${{ github.event.inputs.major_version }} ${{ github.event.inputs.target }}
+      - name: Push new tag
+        run: git push origin ${{ github.event.inputs.major_version }} --force


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the process of updating the major version tag in the repository. The workflow is triggered manually and allows users to specify the target reference and the major version to be updated.

New GitHub Actions workflow:

* [`.github/workflows/update-major-version.yml`](diffhunk://#diff-8ad429b626827e300eb12675405753aa69f57938e8e6fb78e898e47327c8a61bR1-R30): Added a new workflow named `Update Main Version` which includes inputs for `target` and `major_version`, and steps to check out the repository, configure Git, tag the new target, and push the new tag.