### PR TITLE
chore: annotate tag in the update-major-version workflow

### DIFF
--- a/.github/workflows/update-major-version.yml
+++ b/.github/workflows/update-major-version.yml
@@ -15,7 +15,6 @@ on:
 
 permissions:
   contents: write
-  actions: write
 
 jobs:
   tag:


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow file `.github/workflows/update-major-version.yml`. The change adds a message to the `git tag` command to provide more context when updating the tag.

Improvements to the GitHub Actions workflow:

* [`.github/workflows/update-major-version.yml`](diffhunk://#diff-8ad429b626827e300eb12675405753aa69f57938e8e6fb78e898e47327c8a61bL31-R31): Modified the `git tag` command to include a message describing the update, enhancing traceability and context for the tag change.